### PR TITLE
Update readme to include yesod installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ docker-compose up flyway-test
 Tools required:
 * Stack
 * ghcid
+* yesod
 
 ### For nix users
 Start a shell with
@@ -33,6 +34,12 @@ nix-shell
 ```
 
 ## Development
+
+Install yesod with:
+
+``` sh
+stack install yesod-bin --install-ghc
+```
 
 Start a development server with:
 
@@ -84,4 +91,3 @@ nix:
   enable: true
   packages: [ postgresql, zlib.dev, zlib.out ]
 ```
-


### PR DESCRIPTION
During initial setup I ran into errors because I didn't have a `yesod` executable on my path. This was resolved by running `stack install yesod-bin --install-ghc`. Not sure if we want to include the `--install-ghc` tag or not. 